### PR TITLE
feat: add done date property to td items

### DIFF
--- a/src/main/java/com/todarch/td/application/model/TodoDto.java
+++ b/src/main/java/com/todarch/td/application/model/TodoDto.java
@@ -5,6 +5,7 @@ import com.todarch.td.domain.todo.TodoEntity;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,6 +21,7 @@ public class TodoDto {
   private long timeNeededInMin;
   private List<String> tags;
   private Long createdAtEpoch;
+  private Long doneDateEpoch;
 
   /**
    * Maps todoEntity to dto.
@@ -35,6 +37,7 @@ public class TodoDto {
     todoDto.setTimeNeededInMin(todoEntity.timeNeededInMin().toMinutes());
     todoDto.setTags(todoEntity.tags().stream().map(Tag::name).collect(Collectors.toList()));
     todoDto.setCreatedAtEpoch(todoEntity.getCreatedDate().toEpochMilli());
+    todoDto.setDoneDateEpoch(todoEntity.doneDate().orElse(Instant.EPOCH).toEpochMilli());
     return todoDto;
   }
 }

--- a/src/main/java/com/todarch/td/domain/todo/TodoEntity.java
+++ b/src/main/java/com/todarch/td/domain/todo/TodoEntity.java
@@ -22,8 +22,10 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 @Entity
@@ -64,6 +66,9 @@ public class TodoEntity extends AuditEntity {
       inverseJoinColumns = @JoinColumn(name = "tag_id")
   )
   private Set<Tag> tags = new HashSet<>();
+
+  @Column(name = "done_date", nullable = true)
+  private Instant doneDate;
 
   protected TodoEntity() {
     // this is for jpa
@@ -116,6 +121,10 @@ public class TodoEntity extends AuditEntity {
     return Collections.unmodifiableSet(tags);
   }
 
+  public Optional<Instant> doneDate() {
+    return Optional.ofNullable(doneDate);
+  }
+
   /**
    * Sets time needed to complete the todoItem.
    * We may not set this value, and use zero instead.
@@ -139,6 +148,10 @@ public class TodoEntity extends AuditEntity {
     }
     if (TodoStatus.INITIAL.equals(changeTo)) {
       throw new RuntimeException("cannot change to initial state");
+    }
+
+    if (TodoStatus.DONE.equals(changeTo)) {
+      this.doneDate = Instant.now();
     }
 
     this.todoStatus = changeTo;

--- a/src/main/resources/db/migration/V7__add_done_date_column.sql
+++ b/src/main/resources/db/migration/V7__add_done_date_column.sql
@@ -1,0 +1,11 @@
+
+ALTER TABLE todos
+  ADD done_date timestamp;
+
+ALTER TABLE todos ALTER COLUMN done_date
+  SET DEFAULT null;
+
+-- populate the done date for the ones that are already done
+
+UPDATE todos SET done_date = todos.modified_date
+  WHERE todo_status = 1;

--- a/src/test/java/com/todarch/td/domain/todo/TodoEntityTest.java
+++ b/src/test/java/com/todarch/td/domain/todo/TodoEntityTest.java
@@ -64,6 +64,14 @@ public class TodoEntityTest {
   }
 
   @Test
+  public void shouldSetDoneDateWhenStatusChangedToDone() {
+    TodoEntity todoEntity = new TodoEntity();
+    Assertions.assertThat(todoEntity.doneDate()).isEmpty();
+    todoEntity.updateStatusTo(TodoStatus.DONE);
+    Assertions.assertThat(todoEntity.doneDate()).isNotEmpty();
+  }
+
+  @Test
   public void useZeroValueDurationIfNotProvided() {
     TodoEntity todoEntity = new TodoEntity();
     todoEntity.setTimeNeededInMin(null);

--- a/src/test/java/com/todarch/td/rest/todo/TodoControllerIntTest.java
+++ b/src/test/java/com/todarch/td/rest/todo/TodoControllerIntTest.java
@@ -81,7 +81,8 @@ public class TodoControllerIntTest extends BaseIntTest {
         .andExpect(jsonPath("$.status").exists())
         .andExpect(jsonPath("$.timeNeededInMin").exists())
         .andExpect(jsonPath("$.tags").isNotEmpty())
-        .andExpect(jsonPath("$.createdAtEpoch").isNumber());
+        .andExpect(jsonPath("$.createdAtEpoch").isNumber())
+        .andExpect(jsonPath("$.doneDateEpoch").exists());
   }
 
   @Test


### PR DESCRIPTION
When the status of a todo item is changed to 'done',
then the field is set. And never modified.

The items which are done yet, have null value for done date.

The rest api response contains epoch value or 0.

closes #38